### PR TITLE
Alocação da pagina geral dos repositórios como métrica "Collaboration"

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -3,7 +3,7 @@ import HomePage from './pages/HomePage';
 import Commits from './pages/Commits';
 import NotFound from './pages/NotFound';
 import PullRequests from './pages/PullRequests';
-import RepoHome from './pages/RepoHome';
+import CollaborationPage from './pages/Collaboration';
 
 /**
  * App Component
@@ -17,7 +17,7 @@ function App() {
     <Routes>
       <Route path="/" element={<HomePage />} />
       <Route path="/home" element={<HomePage />} />
-      <Route path="/repos" element={<RepoHome />} />
+      <Route path="/repos/collaboration" element={<CollaborationPage />} />
       <Route path="/repos/commits" element={<Commits />} />
       <Route path="/repos/pullrequests" element={<PullRequests />} />
 

--- a/front-end/src/pages/HomePage.tsx
+++ b/front-end/src/pages/HomePage.tsx
@@ -31,7 +31,7 @@ export default function HomePage() {
             <div className="mt-10 space-y-4 animate-fade-in-delayed-2">
               <div className="flex flex-col sm:flex-row gap-4">
                 <div className="hover:scale-105 transition-transform duration-200">
-                  <Link to="/repos" className="botao-principal">
+                  <Link to="/repos/collaboration" className="botao-principal">
                     Ver Métricas
                   </Link>
                 </div>


### PR DESCRIPTION
Havia a rota /repos que continha a página geral dos repositórios. Aloquei essa pagina como uma das métricas, collaboration, e a rota que é acionada quando clica-se no botão 'Ver Métricas' na home agora é /repos/collaboration.